### PR TITLE
fix:properties format configuration object. The scroll bar of the table should not contain the table header

### DIFF
--- a/src/Web/Masa.Dcc.Web.Admin/Masa.Dcc.Web.Admin.Rcl/Pages/Config.razor
+++ b/src/Web/Masa.Dcc.Web.Admin/Masa.Dcc.Web.Admin.Rcl/Pages/Config.razor
@@ -177,7 +177,7 @@
                                         @if (configObject.RelationConfigObjectId != 0)
                                         {
                                             <MCard Style="border:1px solid #E2E7F4;" Class="py-3 mt-4 rounded-5">
-                                                <MDataTable FixedHeader Style="max-height: 312px; overflow: auto;" Headers="Headers"
+                                                <MDataTable FixedHeader Style="max-height: 312px;" Height="312" Headers="Headers"
                                                 SortDesc="true"
                                                 SortBy="new List<string>{ nameof(ConfigObjectPropertyModel.IsPublished) }"
                                                 TItem="ConfigObjectPropertyModel"
@@ -234,7 +234,7 @@
                                                Tabs="@(new List<string>{ T("Table"), T("Text") })">
                                             <SElevationTabItem>
                                             <MCard Style="border:1px solid #E2E7F4; padding: 1px;" Class="py-3 mt-4 rounded-5">
-                                            <MDataTable FixedHeader Style="max-height: 312px; overflow: auto;" Headers="Headers"
+                                            <MDataTable FixedHeader Style="max-height: 312px;" Height="312" Headers="Headers"
                                                         SortDesc="true"
                                                         SortBy="new List<string>{ nameof(ConfigObjectPropertyModel.IsPublished) }"
                                                         TItem="ConfigObjectPropertyModel"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38368335/224301299-c6fcf120-696f-43f8-8eb7-fcf7e04f7b3d.png)