### PR TITLE
Fix: Encrypted configuration objects clicking on publication history …

### DIFF
--- a/src/Services/Masa.Dcc.Service/Application/App/QueryHandler.cs
+++ b/src/Services/Masa.Dcc.Service/Application/App/QueryHandler.cs
@@ -156,6 +156,8 @@ namespace Masa.Dcc.Service.Admin.Application.App
         {
             var configObjectReleases = await _configObjectRepository.GetConfigObjectWithReleaseHistoriesAsync(query.ConfigObejctId);
 
+            Console.WriteLine($"GetConfigObjectReleaseHistoryAsync: queryQarameter[{query.ToJson()}], configObjectReleasesResult[{configObjectReleases?.ToJson()}]");
+
             TypeAdapterConfig<ConfigObject, ConfigObjectWithReleaseHistoryDto>.NewConfig()
                 .Map(dest => dest.ConfigObjectReleases, src => src.ConfigObjectRelease)
                 .Map(dest => dest.Content, src => src.Encryption ? DecryptContent(configObjectReleases.Content) : src.Content)

--- a/src/Web/Masa.Dcc.Web.Admin/Masa.Dcc.Web.Admin.Rcl/Pages/Config.razor.cs
+++ b/src/Web/Masa.Dcc.Web.Admin/Masa.Dcc.Web.Admin.Rcl/Pages/Config.razor.cs
@@ -825,7 +825,7 @@ namespace Masa.Dcc.Web.Admin.Rcl.Pages
             if (_releaseHistory.ConfigObjectReleases.Count <= 1
                 || _releaseHistory.ConfigObjectReleases.First().Version == _releaseHistory.ConfigObjectReleases.Last().Version)
             {
-                await PopupService.EnqueueSnackbarAsync(T("No publishing history can be rolled back"), AlertTypes.Error);
+                _ = InvokeAsync(async () => await PopupService.EnqueueSnackbarAsync(T("No publishing history can be rolled back"), AlertTypes.Error));
                 return;
             }
             var latestConfigObjectRelease = _releaseHistory.ConfigObjectReleases.First();

--- a/src/Web/Masa.Dcc.Web.Admin/Masa.Dcc.Web.Admin.Rcl/Pages/Modal/ReleaseHistoryModal.razor.cs
+++ b/src/Web/Masa.Dcc.Web.Admin/Masa.Dcc.Web.Admin.Rcl/Pages/Modal/ReleaseHistoryModal.razor.cs
@@ -76,7 +76,7 @@ public partial class ReleaseHistoryModal
 
         if (_configObjectReleases.Count < 1)
         {
-            await PopupService.EnqueueSnackbarAsync(T("No publishing history"), AlertTypes.Error);
+            _ = InvokeAsync(async () => await PopupService.EnqueueSnackbarAsync(T("No publishing history"), AlertTypes.Error));
         }
         else
         {


### PR DESCRIPTION
…and rollback will give an error

# Description

_Fix: Encrypted configuration objects clicking on publication history and rollback will give an error_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [√] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
